### PR TITLE
fix bad version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,5 @@ Contributors
 ------------
 
 * Dairon Medina C. <me@dairon.org>
+* Lyle Scott, III <lyle@ls3.io>
 * You?

--- a/README.rst
+++ b/README.rst
@@ -52,26 +52,27 @@ With ``setup.py``:
 
     $ python setup.py install
 
-If you have ``invoke``, you can use it for running the tests and installation:
+With ``setup.py`` but allow edits to the files under ``restcli/`` and reflect
+those changes without having to reinstall ``restcli``:
 
 .. code-block:: sh
 
-    $ invoke test  # Run the tests
+    $ python setup.py develop
+
+If you have ``invoke``, you can use it for running the tests and installation.
+If not, you can install it with ``pip install invoke``.
+
+.. code-block:: sh
+
+    $ invoke test     # Run the tests
     $ invoke install  # Install it
-    $ invoke build  # Run the whole build workflow
-
-If not, you can install it with ``pip``:
-
-.. code-block:: sh
-
-    $ pip install invoke
+    $ invoke build    # Run the whole build workflow
 
 
 Docker
 ------
 
-**restcli** can be run with Docker without additional dependencies.
-Assuming Docker is installed, the Docker image can be built by running:
+Assuming Docker is installed, **restcli** can run inside a container.
 
 .. code-block:: console
 

--- a/restcli/__init__.py
+++ b/restcli/__init__.py
@@ -1,0 +1,4 @@
+from distutils.version import StrictVersion
+
+__strict_version__ = StrictVersion('0.1.0')
+__version__ = str(__strict_version__)

--- a/restcli/cli.py
+++ b/restcli/cli.py
@@ -3,7 +3,7 @@ import sys
 import click
 from click_repl import repl as start_repl
 
-from version import VERSION
+import restcli
 from restcli.app import App
 from restcli.exceptions import (
     CollectionError,
@@ -19,7 +19,7 @@ pass_app = click.make_pass_decorator(App)
 
 @click.group(invoke_without_command=True)
 @click.version_option(
-    VERSION, '-v', '--version',
+    restcli.__version__, '-v', '--version',
     prog_name='restcli',
     message=' '.join((
         '%(prog)s %(version)s',

--- a/setup.py
+++ b/setup.py
@@ -4,24 +4,15 @@
 import os
 import sys
 
-from importlib.machinery import SourceFileLoader
-
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-# avoid loading the package before requirements are installed:
-#version = SourceFileLoader('version', 'version.py').load_module()
-
-#__version__ = str(version.VERSION)
-
 import restcli
-__version__ = restcli.__version__
-
 
 if sys.argv[-1] == 'tag':
-    os.system("git tag -a %s -m 'version %s'" % (__version__, __version__))
+    os.system("git tag -a %s -m 'version %s'" % (restcli.__version__, restcli.__version__))
     os.system("git push --tags")
     sys.exit()
 
@@ -34,14 +25,14 @@ if sys.argv[-1] == 'test':
     os.system('pytest')
     sys.exit()
 
-with open('README.rst', 'r') as f:
+with open('README.rst') as f:
     readme = f.read()
-with open('HISTORY.rst', 'r') as f:
+with open('HISTORY.rst') as f:
     history = f.read()
 
 setup(
     name='restcli',
-    version=__version__,
+    version=restcli.__version__,
     description='An API exploration and testing tool written in Python.',
     long_description=readme + '\n\n' + history,
     author='Dustin Rohde',
@@ -62,6 +53,7 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     """,
     install_requires=[
         'click>=6,<7',
+        'click-repl>0.1,<1',
         'jinja2>=2,<3',
         'prompt_toolkit>=1,<2',
         'Pygments>=2,<3',

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,13 @@ except ImportError:
     from distutils.core import setup
 
 # avoid loading the package before requirements are installed:
-version = SourceFileLoader('version', 'version.py').load_module()
+#version = SourceFileLoader('version', 'version.py').load_module()
 
-__version__ = str(version.VERSION)
+#__version__ = str(version.VERSION)
+
+import restcli
+__version__ = restcli.__version__
+
 
 if sys.argv[-1] == 'tag':
     os.system("git tag -a %s -m 'version %s'" % (__version__, __version__))

--- a/version.py
+++ b/version.py
@@ -1,5 +1,0 @@
-from distutils.version import StrictVersion
-
-__all__ = ['VERSION']
-
-VERSION = StrictVersion('0.1.0')


### PR DESCRIPTION
You can not use the installed package. `restcli/cli.py` was importing and using `version.py` to grab the version. BUT, you don't install that when you install `restcli`. So, this patch just reworks the versioning a bit better. `__version__` is a bit more standard, too. 